### PR TITLE
Cygwin

### DIFF
--- a/cli/mainfeatures.cpp
+++ b/cli/mainfeatures.cpp
@@ -107,6 +107,24 @@ namespace std {
 
 using namespace Cli;
 
+template <> struct hash<KnownField>
+{
+    std::size_t operator()(const KnownField &ids) const
+    {
+        using type = typename std::underlying_type<KnownField>::type;
+        return std::hash<type>()(static_cast<type>(ids));
+    }
+};
+
+template <> struct hash<TagType>
+{
+    std::size_t operator()(const TagType &ids) const
+    {
+        using type = typename std::underlying_type<TagType>::type;
+        return std::hash<type>()(static_cast<type>(ids));
+    }
+};
+
 template <> struct hash<TagTarget::IdContainerType>
 {
     std::size_t operator()(const TagTarget::IdContainerType &ids) const


### PR DESCRIPTION
I am trying to build TagEditor so I can try out the [new commit][1].

The [instructions say][2]:

~~~
${_arch}-cmake
~~~

but this does not make sense, because the Cygwin cmake package only has these
commands:

    usr/bin/ccmake.exe
    usr/bin/cmake.exe
    usr/bin/cpack.exe
    usr/bin/ctest.exe

Please advise, thank you.

[1]://github.com/Martchus/tagparser/commit/f6d0f3a
[2]://github.com/Martchus/cpp-utilities#building-for-windows