### PR TITLE
TagEditor refuses to build without Qt

### DIFF
--- a/application/main.cpp
+++ b/application/main.cpp
@@ -7,10 +7,9 @@
 
 #include "resources/config.h"
 
-#include <qtutilities/misc/conversion.h>
-
 #if defined(GUI_QTWIDGETS) || defined(GUI_QTQUICK)
 # include <qtutilities/resources/qtconfigarguments.h>
+# include <qtutilities/misc/conversion.h>
 #else
 # include <c++utilities/application/fakeqtconfigarguments.h>
 #endif

--- a/cli/mainfeatures.cpp
+++ b/cli/mainfeatures.cpp
@@ -12,8 +12,6 @@
 #include <tagparser/abstractattachment.h>
 #include <tagparser/abstractchapter.h>
 
-#include <qtutilities/misc/conversion.h>
-
 #include <c++utilities/application/failure.h>
 #include <c++utilities/application/commandlineutils.h>
 #include <c++utilities/conversion/stringconversion.h>
@@ -25,6 +23,7 @@
 
 #if defined(GUI_QTWIDGETS) || defined(GUI_QTQUICK)
 # include <QDir>
+# include <qtutilities/misc/conversion.h>
 #endif
 
 #include <iostream>


### PR DESCRIPTION

~~~
application/main.cpp:10:41: fatal error:
qtutilities/misc/conversion.h: No such file or directory
~~~

http://github.com/svnpenn/glade/blob/master/tageditor/install.sh