### PR TITLE
fix(cli): typo in field name 'exectiveproducer' to 'executiveproducer'

### DIFF
--- a/cli/mainfeatures.cpp
+++ b/cli/mainfeatures.cpp
@@ -95,7 +95,7 @@ namespace Cli {
     "      subtitle leadperformer arranger conductor director assistantdirector\n"                                                                   \
     "      directorofphotography soundengineer artdirector productiondesigner choregrapher\n"                                                        \
     "      costumedesigner actor character writtenby screenplayby editedby producer\n"                                                               \
-    "      coproducer exectiveproducer distributedby masteredby encodedby mixedby\n"                                                                 \
+    "      coproducer executiveproducer distributedby masteredby encodedby mixedby\n"                                                                 \
     "      remixedby productionstudio thanksto publisher mood originalmediatype\n"                                                                   \
     "      contenttype subject keywords summary synopsis initialkey period lawrating\n"                                                              \
     "      encodingdate taggingdate originalreleasedate digitalizationdate writingdate\n"                                                            \


### PR DESCRIPTION
The output of `tageditor print-field-names` contains 'exectiveproducer',
but `KnownField::ExecutiveProducer` doesn't have the same typo.

Presumably, trying to tag with this will fail.